### PR TITLE
Fix numpy compatibility layer export and add coverage

### DIFF
--- a/src/dividebyzero/numpy_compat.py
+++ b/src/dividebyzero/numpy_compat.py
@@ -4,23 +4,42 @@ Allows dbz to act as a complete drop-in replacement for numpy.
 """
 
 import numpy as np
-from functools import wraps
 import inspect
-from .numpy_registry import wrap_and_register_numpy_function, get_numpy_function
 
-# Register numpy functions
+from .numpy_registry import wrap_and_register_numpy_function
+
+
+# Keep track of names we intentionally export
+_exported_names = []
+
+# Register numpy functions and constants in the module namespace
 for name in dir(np):
-    if name.startswith('_'):
+    if name.startswith("_"):
         continue
-    
-    obj = getattr(np, name)
-    # Only wrap actual functions, not classes, modules, or other objects
-    if callable(obj) and not inspect.isclass(obj) and not inspect.ismodule(obj) and hasattr(obj, '__name__'):
-        try:
-            wrap_and_register_numpy_function(obj)
-        except (AttributeError, TypeError):
-            # Skip objects that can't be wrapped
-            continue
 
-# Export numpy functions
-__all__ = [name for name in dir(np) if not name.startswith('_')] 
+    obj = getattr(np, name)
+
+    if (
+        callable(obj)
+        and not inspect.isclass(obj)
+        and not inspect.ismodule(obj)
+        and hasattr(obj, "__name__")
+    ):
+        try:
+            # Wrap numpy functions so they understand DimensionalArray inputs
+            globals()[name] = wrap_and_register_numpy_function(obj)
+            _exported_names.append(name)
+        except (AttributeError, TypeError):
+            # Some numpy objects (like ufuncs without names) cannot be wrapped
+            continue
+    else:
+        # Expose non-callable objects (constants, etc.) directly
+        globals()[name] = obj
+        _exported_names.append(name)
+
+# Export only the numpy names we populated above
+__all__ = _exported_names
+
+# Prevent leaking internal helpers
+del np, inspect, wrap_and_register_numpy_function, _exported_names
+

--- a/tests/test_numpy_compat.py
+++ b/tests/test_numpy_compat.py
@@ -1,0 +1,31 @@
+"""Tests for the numpy compatibility layer."""
+
+import numpy as np
+from dividebyzero import array, DimensionalArray
+import dividebyzero.numpy_compat as numpy_compat
+from dividebyzero.numpy_compat import sin, pi
+
+
+def test_numpy_compat_exports_functions_and_constants():
+    """sin and constants like pi should be available from numpy_compat."""
+    arr = array([0, pi / 2])
+    result = sin(arr)
+
+    assert isinstance(result, DimensionalArray)
+    assert np.allclose(result.array, np.sin(arr.array))
+    assert np.isclose(pi, np.pi)
+
+
+def test_numpy_compat_does_not_expose_internal_helpers():
+    """Internal implementation details should not be publicly exported."""
+
+    # None of the helper names should be present in the public API
+    assert "np" not in numpy_compat.__all__
+    assert "inspect" not in numpy_compat.__all__
+    assert "wrap_and_register_numpy_function" not in numpy_compat.__all__
+
+    # These names are also removed from the module namespace
+    assert not hasattr(numpy_compat, "np")
+    assert not hasattr(numpy_compat, "inspect")
+    assert not hasattr(numpy_compat, "wrap_and_register_numpy_function")
+


### PR DESCRIPTION
## Summary
- ensure `dividebyzero.numpy_compat` exports wrapped NumPy functions and constants
- restrict `numpy_compat.__all__` to NumPy-provided names and remove internal helpers
- add tests verifying public API includes wrapped `sin`/`pi` and omits helper symbols
- align import order with main branch after merge

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894ea84756883249e45368705f732ed