### PR TITLE
Clarify module import style

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ reconstructed = result.elevate()
 ### Key Features
 
 #### 1. Transparent NumPy Integration
-- Drop-in replacement for numpy operations
+- Use ``import dividebyzero as dbz`` and call NumPy-like functions directly
+  (``dbz.array``, ``dbz.zeros``)
+- For rare drop-in scenarios, ``dbz.numpy_compat`` mirrors the NumPy API
 - Preserves standard numerical behavior
 - Extends functionality to handle singularities
 
@@ -55,11 +57,10 @@ reconstructed = result.elevate()
 
 #### 3. Advanced Mathematical Operations
 ```python
-# Quantum tensor operations
-from dividebyzero.quantum import QuantumTensor
+import dividebyzero as dbz
 
-# Create quantum-aware tensor
-q_tensor = QuantumTensor(data, physical_dims=(2, 2, 2))
+# Quantum tensor operations
+q_tensor = dbz.quantum.QuantumTensor(data, physical_dims=(2, 2, 2))
 
 # Perform gauge-invariant reduction
 reduced = q_tensor.reduce_dimension(

--- a/src/dividebyzero/__init__.py
+++ b/src/dividebyzero/__init__.py
@@ -1,4 +1,4 @@
-"""dividebyzero: dimensional-safe numerical computing.
+"""Dividebyzero: dimensional-safe numerical computing.
 
 This package is designed to be imported as ``import dividebyzero as dbz``.
 Top-level APIs such as :func:`dbz.array`, :func:`dbz.zeros`, and

--- a/src/dividebyzero/__init__.py
+++ b/src/dividebyzero/__init__.py
@@ -1,5 +1,11 @@
-"""
-Dividebyzero: A framework for handling singularities in numerical computations.
+"""dividebyzero: dimensional-safe numerical computing.
+
+This package is designed to be imported as ``import dividebyzero as dbz``.
+Top-level APIs such as :func:`dbz.array`, :func:`dbz.zeros`, and
+class :class:`dbz.DimensionalArray` are available directly from the
+``dbz`` namespace.  Use :mod:`dbz.numpy_compat` only when a drop-in
+replacement for ``numpy`` is explicitly required; typical code should
+prefer the simpler ``import dividebyzero as dbz`` form.
 """
 
 import numpy as np

--- a/src/dividebyzero/array.py
+++ b/src/dividebyzero/array.py
@@ -1,5 +1,8 @@
 """
 Core array implementation with division by zero support.
+
+Access through ``dbz.array`` and ``dbz.DimensionalArray`` after
+``import dividebyzero as dbz``.
 """
 
 import numpy as np

--- a/src/dividebyzero/linalg.py
+++ b/src/dividebyzero/linalg.py
@@ -1,3 +1,11 @@
+"""
+Linear algebra helpers that mirror :mod:`numpy.linalg` but operate on
+``DimensionalArray`` inputs.
+
+After ``import dividebyzero as dbz`` these routines are available under
+``dbz.linalg``.
+"""
+
 import numpy as np
 from scipy.linalg import logm as scipy_logm
 from .array import DimensionalArray

--- a/src/dividebyzero/numpy_compat.py
+++ b/src/dividebyzero/numpy_compat.py
@@ -1,6 +1,9 @@
 """
-Numpy compatibility layer for dividebyzero.
-Allows dbz to act as a complete drop-in replacement for numpy.
+NumPy compatibility layer for DivideByZero.
+
+Access this module via ``dbz.numpy_compat`` after ``import dividebyzero as
+dbz``.  It lets DivideByZero act as a drop-in replacement for NumPy, but most
+code can simply use the top-level ``dbz`` API directly.
 """
 
 import numpy as np


### PR DESCRIPTION
## Summary
- Clarify that `dividebyzero` is typically imported as `dbz`
- Document direct access to top-level APIs and niche role of `numpy_compat`

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894eae7d2c08324a739d363695622e9