### PR TITLE
Add demonstration suite with examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 data/
-examples/

--- a/README.md
+++ b/README.md
@@ -141,6 +141,20 @@ reconstructed = reduced_data.elevate()
 pytest tests/
 ```
 
+## Demonstration Suite
+
+Standalone examples are available in the [`examples/`](examples/) directory to
+showcase typical usage patterns and advanced features:
+
+```bash
+python examples/basic_reduction.py      # Dimensional reduction and registry
+python examples/numpy_integration.py    # NumPy-compatible operations
+python examples/quantum_tensor.py       # Quantum tensor utilities
+```
+
+Each script prints intermediate results illustrating how the library safely
+handles division by zero while preserving recoverable information.
+
 ## Mathematical Documentation
 
 Detailed mathematical foundations are available in the [Technical Documentation](docs/theory.md), including:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,19 @@
+# DivideByZero Demonstration Suite
+
+This directory contains standalone examples showing how to use the `dividebyzero` library and illustrating its unique dimensional–reduction features.
+
+## Available Examples
+
+- **`basic_reduction.py`** – Introduction to dimensional reduction and reconstruction using the global error registry.
+- **`numpy_integration.py`** – Using DivideByZero as a drop‑in replacement for NumPy functions and performing safe division by zero.
+- **`quantum_tensor.py`** – Demonstrates the quantum tensor utilities and entanglement‑preserving dimensional reduction.
+
+Run any script directly with Python:
+
+```bash
+python examples/basic_reduction.py
+python examples/numpy_integration.py
+python examples/quantum_tensor.py
+```
+
+Each script prints intermediate values to illustrate how DivideByZero handles singular operations while preserving information.

--- a/examples/basic_reduction.py
+++ b/examples/basic_reduction.py
@@ -1,0 +1,31 @@
+"""Basic dimensional reduction demonstration."""
+import pathlib
+import sys
+
+# Allow running the example without installing the package
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+import dividebyzero as dbz
+
+
+def main() -> None:
+    # Create a 2D array and divide by zero to trigger dimensional reduction
+    arr = dbz.array([[1, 2, 3], [4, 5, 6]])
+    reduced = arr / 0
+
+    print("Original shape:", arr.shape)
+    print("Reduced representation:", reduced.array)
+
+    # Reconstruct the original dimensions
+    reconstructed = reduced.elevate()
+    print("Reconstructed shape:", reconstructed.shape)
+    print("Reconstructed array:\n", reconstructed.array)
+
+    # Inspect the stored error information
+    registry = dbz.get_registry()
+    error = registry.retrieve(reduced._error_id)
+    print("Stored error reduction type:", error.reduction_type)
+    print("Error tensor shape:", error.error_tensor.shape)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/numpy_integration.py
+++ b/examples/numpy_integration.py
@@ -1,0 +1,32 @@
+"""Demonstrate NumPy compatibility of DivideByZero."""
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+import dividebyzero as dbz
+
+
+def main() -> None:
+    a = dbz.array([[1, 2], [3, 4]])
+    b = dbz.array([[2, 0], [0, 2]])
+
+    # Use NumPy-style operations through the dbz namespace
+    c = dbz.matmul(a, b)
+    print("Matrix product:\n", c.array)
+
+    # Apply element-wise functions
+    s = dbz.sin(a)
+    print("Sine of array:\n", s.array)
+
+    # Safe division by zero with reconstruction
+    reduced = b / 0
+    print("Reduced after division by zero:\n", reduced.array)
+    print("Elevated back:\n", reduced.elevate().array)
+
+    # Example of a linear algebra routine
+    logm_a = dbz.linalg.logm(a)
+    print("Matrix logarithm:\n", logm_a.array)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/quantum_tensor.py
+++ b/examples/quantum_tensor.py
@@ -1,0 +1,27 @@
+"""Quantum tensor dimensional reduction example."""
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+import dividebyzero as dbz
+
+
+def main() -> None:
+    # Construct a simple 3-qubit state
+    data = [[[1, 0], [0, 1]],
+            [[0, 1], [1, 0]]]
+    qt = dbz.quantum.QuantumTensor(data, physical_dims=(2, 2, 2))
+
+    print("Original tensor shape:", qt.data.shape)
+
+    # Reduce tensor dimensions while preserving entanglement
+    reduced = qt.reduce_dimension(target_dims=2)
+    print("Reduced tensor shape:", reduced.data.shape)
+
+    # Elevate back to demonstrate reconstruction
+    elevated = reduced.elevate()
+    print("Elevated tensor shape:", elevated.data.shape)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `examples` directory with demonstration scripts for dimensional reduction, NumPy integration, and quantum tensor utilities
- Document example usage in README and include guidance for running the scripts
- Stop ignoring `examples/` in `.gitignore`

## Testing
- `PYTHONPATH=src pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_68b8e8c90ad083248a883751d7c4046d