### PR TITLE
Expand demonstration suite with real-world examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 data/
-examples/

--- a/README.md
+++ b/README.md
@@ -141,6 +141,23 @@ reconstructed = reduced_data.elevate()
 pytest tests/
 ```
 
+## Demonstration Suite
+
+Standalone examples are available in the [`examples/`](examples/) directory to
+showcase typical usage patterns and advanced features:
+
+```bash
+python examples/basic_reduction.py      # Dimensional reduction and registry
+python examples/numpy_integration.py    # NumPy-compatible operations
+python examples/quantum_tensor.py       # Quantum tensor utilities
+python examples/financial_returns.py    # Market returns with zero-price days
+python examples/web_pagerank.py         # PageRank transition matrix without NaNs
+python examples/image_normalization.py  # Image normalization with dark pixels
+```
+
+Each script prints intermediate results illustrating how the library safely
+handles division by zero while preserving recoverable information.
+
 ## Mathematical Documentation
 
 Detailed mathematical foundations are available in the [Technical Documentation](docs/theory.md), including:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,25 @@
+# DivideByZero Demonstration Suite
+
+This directory contains standalone examples showing how to use the `dividebyzero` library and illustrating its unique dimensional–reduction features.
+
+## Available Examples
+
+- **`basic_reduction.py`** – Introduction to dimensional reduction and reconstruction using the global error registry.
+- **`numpy_integration.py`** – Using DivideByZero as a drop‑in replacement for NumPy functions and performing safe division by zero.
+- **`quantum_tensor.py`** – Demonstrates the quantum tensor utilities and entanglement‑preserving dimensional reduction.
+- **`financial_returns.py`** – Computes stock returns when prior prices hit zero, preserving market information instead of producing `inf`.
+- **`web_pagerank.py`** – Builds a transition matrix for a small web graph with dangling nodes, enabling PageRank-style algorithms without NaNs.
+- **`image_normalization.py`** – Normalizes an image by an illumination map containing dark pixels while retaining reconstruction data.
+
+Run any script directly with Python:
+
+```bash
+python examples/basic_reduction.py
+python examples/numpy_integration.py
+python examples/quantum_tensor.py
+python examples/financial_returns.py
+python examples/web_pagerank.py
+python examples/image_normalization.py
+```
+
+Each script prints intermediate values to illustrate how DivideByZero handles singular operations while preserving information.

--- a/examples/basic_reduction.py
+++ b/examples/basic_reduction.py
@@ -1,0 +1,31 @@
+"""Basic dimensional reduction demonstration."""
+import pathlib
+import sys
+
+# Allow running the example without installing the package
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+import dividebyzero as dbz
+
+
+def main() -> None:
+    # Create a 2D array and divide by zero to trigger dimensional reduction
+    arr = dbz.array([[1, 2, 3], [4, 5, 6]])
+    reduced = arr / 0
+
+    print("Original shape:", arr.shape)
+    print("Reduced representation:", reduced.array)
+
+    # Reconstruct the original dimensions
+    reconstructed = reduced.elevate()
+    print("Reconstructed shape:", reconstructed.shape)
+    print("Reconstructed array:\n", reconstructed.array)
+
+    # Inspect the stored error information
+    registry = dbz.get_registry()
+    error = registry.retrieve(reduced._error_id)
+    print("Stored error reduction type:", error.reduction_type)
+    print("Error tensor shape:", error.error_tensor.shape)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/financial_returns.py
+++ b/examples/financial_returns.py
@@ -1,0 +1,29 @@
+"""Financial return calculation with zero-price days."""
+import pathlib
+import sys
+
+# Allow running the example without installing the package
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+import dividebyzero as dbz
+
+
+def main() -> None:
+    # Simulated daily closing prices with a trading halt day at zero
+    prices = dbz.array([100, 105, 0, 110])
+    returns = (prices[1:] - prices[:-1]) / prices[:-1]
+
+    print("Prices:", prices.array)
+    print("Daily returns:", returns.array)
+
+    # Reconstruct information lost during the zero-price division
+    reconstructed = returns.elevate()
+    print("Reconstructed returns:", reconstructed.array)
+
+    registry = dbz.get_registry()
+    error = registry.retrieve(returns._error_id)
+    print("Stored reduction type:", error.reduction_type)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/examples/image_normalization.py
+++ b/examples/image_normalization.py
@@ -1,0 +1,34 @@
+"""Image normalization with zero-valued illumination."""
+import pathlib
+import sys
+
+# Allow running the example without installing the package
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+import dividebyzero as dbz
+
+
+def main() -> None:
+    # Grayscale image and illumination map with dark pixels
+    image = dbz.array([
+        [0, 50, 100],
+        [150, 200, 0],
+    ])
+    illumination = dbz.array([
+        [1, 0, 2],
+        [3, 4, 0],
+    ])
+
+    normalized = image / illumination
+
+    print("Image:\n", image.array)
+    print("Illumination:\n", illumination.array)
+    print("Normalized image:\n", normalized.array)
+
+    # Recover full information for pixels where illumination was zero
+    elevated = normalized.elevate()
+    print("Elevated normalized image:\n", elevated.array)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/examples/numpy_integration.py
+++ b/examples/numpy_integration.py
@@ -1,0 +1,32 @@
+"""Demonstrate NumPy compatibility of DivideByZero."""
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+import dividebyzero as dbz
+
+
+def main() -> None:
+    a = dbz.array([[1, 2], [3, 4]])
+    b = dbz.array([[2, 0], [0, 2]])
+
+    # Use NumPy-style operations through the dbz namespace
+    c = dbz.matmul(a, b)
+    print("Matrix product:\n", c.array)
+
+    # Apply element-wise functions
+    s = dbz.sin(a)
+    print("Sine of array:\n", s.array)
+
+    # Safe division by zero with reconstruction
+    reduced = b / 0
+    print("Reduced after division by zero:\n", reduced.array)
+    print("Elevated back:\n", reduced.elevate().array)
+
+    # Example of a linear algebra routine
+    logm_a = dbz.linalg.logm(a)
+    print("Matrix logarithm:\n", logm_a.array)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/quantum_tensor.py
+++ b/examples/quantum_tensor.py
@@ -1,0 +1,27 @@
+"""Quantum tensor dimensional reduction example."""
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+import dividebyzero as dbz
+
+
+def main() -> None:
+    # Construct a simple 3-qubit state
+    data = [[[1, 0], [0, 1]],
+            [[0, 1], [1, 0]]]
+    qt = dbz.quantum.QuantumTensor(data, physical_dims=(2, 2, 2))
+
+    print("Original tensor shape:", qt.data.shape)
+
+    # Reduce tensor dimensions while preserving entanglement
+    reduced = qt.reduce_dimension(target_dims=2)
+    print("Reduced tensor shape:", reduced.data.shape)
+
+    # Elevate back to demonstrate reconstruction
+    elevated = reduced.elevate()
+    print("Elevated tensor shape:", elevated.data.shape)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/web_pagerank.py
+++ b/examples/web_pagerank.py
@@ -1,0 +1,33 @@
+"""PageRank transition matrix with dangling nodes."""
+import pathlib
+import sys
+
+# Allow running the example without installing the package
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+import dividebyzero as dbz
+
+
+def main() -> None:
+    # Simple web graph: node 2 has no outgoing links
+    adjacency = dbz.array([
+        [0, 1, 1],
+        [0, 0, 0],
+        [1, 0, 0],
+    ])
+
+    out_degree = adjacency.sum(axis=1)
+    # Broadcast out-degree across columns to avoid invalid indexing
+    out_matrix = dbz.array([[d, d, d] for d in out_degree.array])
+    transition = adjacency / out_matrix
+
+    print("Adjacency matrix:\n", adjacency.array)
+    print("Transition matrix:\n", transition.array)
+
+    # Reconstruct transition probabilities for dangling nodes
+    elevated = transition.elevate()
+    print("Elevated transition matrix:\n", elevated.array)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- Document additional example scripts showcasing market analytics, web ranking, and image workflows
- Add financial returns, PageRank, and image normalization demonstrations to the examples directory
- Reference new examples in the project README and examples README

## Testing
- `PYTHONPATH=src pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68b8e8c90ad083248a883751d7c4046d