### PR TITLE
Expose pinv and improve numpy passthrough

### DIFF
--- a/src/dividebyzero/numpy_compat.py
+++ b/src/dividebyzero/numpy_compat.py
@@ -62,5 +62,5 @@ for name in _wrapped_np.__all__:
     globals()[name] = getattr(_wrapped_np, name)
 
 # Export all public names we just populated
-__all__ = [name for name in globals() if not name.startswith("_")]
+__all__ = _wrapped_np.__all__
 

--- a/src/dividebyzero/numpy_registry.py
+++ b/src/dividebyzero/numpy_registry.py
@@ -8,20 +8,29 @@ from functools import wraps
 
 _numpy_functions: Dict[str, Callable] = {}
 
-def register_numpy_function(name: str, func: Callable) -> None:
-    """Register a numpy function with its wrapped version."""
-    _numpy_functions[name] = func
 
-def get_numpy_function(name: str) -> Optional[Callable]:
+def _make_key(np_func: Callable) -> str:
+    """Return a unique key for a NumPy function based on its module and name."""
+    return f"{np_func.__module__}.{np_func.__name__}"
+
+
+def register_numpy_function(full_name: str, func: Callable) -> None:
+    """Register a numpy function with its wrapped version."""
+    _numpy_functions[full_name] = func
+
+
+def get_numpy_function(full_name: str) -> Optional[Callable]:
     """Get the wrapped version of a numpy function if it exists."""
-    return _numpy_functions.get(name)
+    return _numpy_functions.get(full_name)
+
 
 def wrap_and_register_numpy_function(np_func: Callable) -> Callable:
     """Decorator to wrap and register a numpy function."""
     from .array import DimensionalArray
 
-    if np_func.__name__ in _numpy_functions:
-        return _numpy_functions[np_func.__name__]
+    key = _make_key(np_func)
+    if key in _numpy_functions:
+        return _numpy_functions[key]
 
     @wraps(np_func)
     def wrapper(*args, **kwargs):
@@ -39,5 +48,5 @@ def wrap_and_register_numpy_function(np_func: Callable) -> Callable:
             return tuple(DimensionalArray(r) if isinstance(r, np.ndarray) else r for r in result)
         return result
 
-    register_numpy_function(np_func.__name__, wrapper)
+    register_numpy_function(key, wrapper)
     return wrapper


### PR DESCRIPTION
## Summary
- add `pinv` wrapper so pseudo-inverse works with `DimensionalArray`
- recursively wrap numpy submodules to expose their functions while respecting existing API
- avoid overwriting existing symbols when registering numpy functions
- export only wrapped NumPy functions from `numpy_compat`
- disambiguate registry entries by module path to prevent collisions

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd9b0dd8148324b5730d73b6c87023